### PR TITLE
Adding an experimental GKE Fleet to ClusterProfile syncer

### DIFF
--- a/fleet-clusterprofile-syncer/Dockerfile
+++ b/fleet-clusterprofile-syncer/Dockerfile
@@ -1,0 +1,5 @@
+FROM google/cloud-sdk:latest
+
+RUN apt-get update && apt-get install -qqy kubectl uuid-runtime jq
+
+ADD membership-to-clusterprofile.sh /usr/sbin/membership-to-clusterprofile.sh

--- a/fleet-clusterprofile-syncer/README.md
+++ b/fleet-clusterprofile-syncer/README.md
@@ -1,0 +1,27 @@
+# [Experimental] Membership to ClusterProfile syncer
+
+This bash-based syncer regularly pulls GKE Fleet Memberships and writes them as ClusterProfiles into a namespace named after the project id.
+It handles creation, update and deletion of the ClusterProfiles. It sets up the GKE Connect Gateway endpoint in annotations so that Clusters can be accessed easily and without requiring additional credentials (as long as Workload Identity is setup in the management cluster).
+
+It can be easily modified to show integrations of GKE Fleet with ClusterProfiles and specific applications.
+
+
+## Prerequisites
+
+1. Configure AR to be used in docker push
+
+```
+gcloud auth configure-docker us-west1-docker.pkg.dev
+```
+
+## Install
+
+```
+./install.sh
+```
+
+## Clean up
+
+```
+kubectl delete namespace $(gcloud config get-value project)
+```

--- a/fleet-clusterprofile-syncer/cluster-profile-crd.yaml
+++ b/fleet-clusterprofile-syncer/cluster-profile-crd.yaml
@@ -1,0 +1,198 @@
+---
+# https://raw.githubusercontent.com/kubernetes-sigs/cluster-inventory-api/main/config/crd/bases/multicluster.x-k8s.io_clusterprofiles.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: clusterprofiles.multicluster.x-k8s.io
+spec:
+  group: multicluster.x-k8s.io
+  names:
+    kind: ClusterProfile
+    listKind: ClusterProfileList
+    plural: clusterprofiles
+    singular: clusterprofile
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterProfile represents a single cluster in a multi-cluster
+          deployment.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterProfileSpec defines the desired state of ClusterProfile.
+            properties:
+              clusterManager:
+                description: ClusterManager defines which cluster manager owns this
+                  ClusterProfile resource
+                properties:
+                  name:
+                    description: Name defines the name of the cluster manager
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: ClusterManager is immutable
+                  rule: self == oldSelf
+              displayName:
+                description: DisplayName defines a human-readable name of the ClusterProfile
+                type: string
+            required:
+            - clusterManager
+            type: object
+          status:
+            description: ClusterProfileStatus defines the observed state of ClusterProfile.
+            properties:
+              conditions:
+                description: Conditions contains the different condition statuses
+                  for this cluster.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              properties:
+                description: |-
+                  Properties defines name/value pairs to represent properties of a cluster.
+                  It could be a collection of ClusterProperty (KEP-2149) resources,
+                  but could also be info based on other implementations.
+                  The names of the properties can be predefined names from ClusterProperty resources
+                  and is allowed to be customized by different cluster managers.
+                items:
+                  description: |-
+                    Property defines a name/value pair to represent a property of a cluster.
+                    It could be a ClusterProperty (KEP-2149) resource,
+                    but could also be info based on other implementations.
+                    The name of the property can be predefined name from a ClusterProperty resource
+                    and is allowed to be customized by different cluster managers.
+                    This property can store various configurable details and metrics of a cluster,
+                    which may include information such as the number of nodes, total and free CPU,
+                    and total and free memory, among other potential attributes.
+                  properties:
+                    name:
+                      description: |-
+                        Name is the name of a property resource on cluster. It's a well-known
+                        or customized name to identify the property.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    value:
+                      description: Value is a property-dependent string
+                      maxLength: 1024
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+              version:
+                description: Version defines the version information of the cluster.
+                properties:
+                  kubernetes:
+                    description: Kubernetes is the kubernetes version of the cluster.
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: clusterprofileadmin
+  labels:
+    # Add these permissions to the "admin" default role.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups: ["multicluster.x-k8s.io"]
+  resources: ["clusterprofiles"]
+  verbs: ["*"]

--- a/fleet-clusterprofile-syncer/install.sh
+++ b/fleet-clusterprofile-syncer/install.sh
@@ -1,0 +1,47 @@
+
+project_id=${project_id:-"$(gcloud config get-value project)"}
+project_number=$(gcloud projects describe "$project_id" --format "value(projectNumber)")
+location=${location:-"us-west1"}
+cluster_name=${cluster_name:-"management-cluster"}
+membership_name="projects/$project_id/locations/$location/memberships/$cluster_name"
+syncerrepo="clusterprofile-syncer"
+syncer_docker_image="$location-docker.pkg.dev/$project_id/${syncerrepo}/syncer:latest"
+date=$(date) # used to get a unique pod so it forces a rollout
+
+# create the repository if it doesn't exist
+gcloud artifacts repositories describe $syncerrepo --location $location --project $project_id || result="$?"
+if [[ $result -ne 0 ]]; then
+  gcloud artifacts repositories create $syncerrepo --location $location --project $project_id --repository-format=docker
+fi
+
+docker build -t $syncer_docker_image .
+docker push $syncer_docker_image
+
+# create the management cluster if it doesn't exist
+gcloud container clusters describe $cluster_name --location $location --project $project_id || result="$?"
+if [[ $result -ne 0 ]]; then
+  gcloud container clusters create-auto $cluster_name --location $location --project $project_id --enable-fleet
+fi
+
+gcloud container fleet memberships get-credentials $membership_name
+
+# management cluster uses GKE WI, we need to give it access to pull memberships.
+gcloud projects add-iam-policy-binding $project_id \
+  --member="principal://iam.googleapis.com/projects/$project_number/locations/global/workloadIdentityPools/$project_id.svc.id.goog/subject/ns/$project_id/sa/clusterprofile-syncer" \
+  --role="roles/gkehub.viewer" --condition="None"
+
+
+gcloud projects add-iam-policy-binding $project_id \
+  --member="principal://iam.googleapis.com/projects/$project_number/locations/global/workloadIdentityPools/$project_id.svc.id.goog/subject/ns/$project_id/sa/clusterprofile-syncer" \
+  --role="roles/gkehub.gatewayReader" --condition="None"
+
+kubectl apply -f cluster-profile-crd.yaml
+kubectl create namespace $project_id || true
+
+kubectl delete configmap membership-to-clusterprofile -n $project_id || true
+kubectl create configmap membership-to-clusterprofile --from-file membership-to-clusterprofile.sh -n $project_id
+
+rm -f syncer_hydrated.yaml
+PROJECT=$project_id MEMBERSHIP_NAME=$membership_name PROJECT_NUMBER=$project_number SYNCER_DOCKER_IMAGE=$syncer_docker_image DATE=$date envsubst < syncer.yaml > syncer_hydrated.yaml
+
+kubectl apply -f syncer_hydrated.yaml -n $project_id

--- a/fleet-clusterprofile-syncer/membership-to-clusterprofile.sh
+++ b/fleet-clusterprofile-syncer/membership-to-clusterprofile.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Usage:
+# ./membership-to-clusterprofile.sh $PROJECT $MANAGEMENT_MEMBERSHIP_NAME
+# Example:
+# ./membership-to-clusterprofile.sh my-project projects/my-project/locations/us-central1/memberships/my-management-membership
+
+# Project to get the memberships from, also used as the namespace name.
+project=$1
+membership_management_cluster=$2
+project_number=$3
+echo "using project=$project"
+echo "using membership_management_cluster=$membership_management_cluster"
+echo "using project_number=$project_number"
+
+# only needed when running outside the cluster
+# gcloud container fleet memberships get-credentials  --project $project $membership_management_cluster
+
+function syncClusterProfiles() {
+  # used to know the "current" clusterProfiles and delete old ones.
+  run_uuid=$(uuidgen)
+  echo "new run: $run_uuid, $(date)"
+  folder="./inventory-$project-$run_uuid"
+
+  mkdir $folder
+
+  # Get the list of Fleet memberships and write related ClusterProfiles
+  # This ignore any health status or type
+
+  while read -r id name version shortName location; do
+      echo "Membership name: $name, version: $version, id: $id, location: $location, shortName:$shortName"
+
+    endpointRes=$(curl -s -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+      -H "X-GFE-SSL: yes" \
+      "https://$location-connectgateway.googleapis.com/v1/projects/$project_number/locations/$location/memberships/$shortName:generateCredentials")
+    # echo $endpointRes
+    endpoint=$( echo $endpointRes | jq .endpoint)
+
+      read -r -d '' crdContent << EOM
+---
+apiVersion: multicluster.x-k8s.io/v1alpha1
+kind: ClusterProfile
+metadata:
+ name: $shortName-$location
+ namespace: $project
+ labels:
+   x-k8s.io/cluster-manager: fleet-memberships-to-clusterprofile-script
+   run_uuid: $run_uuid
+   location: $location
+ annotations:
+   membership-uuid: $id
+   endpoint: $endpoint
+   endpoint_type: gke-connect-gateway
+   argocdns: argocd
+spec:
+  displayName: $name
+  clusterManager:
+    name: fleet-memberships-to-clusterprofile-script
+status:
+ version:
+   kubernetes: $version
+ properties:
+   - name: clusterset.k8s.io
+     value: $project
+   - name: location
+     value: $location
+EOM
+
+  echo "$crdContent"
+  filename="$folder/$shortName-$location.yaml"
+  echo "$crdContent" > "$filename"
+
+  done< <(gcloud container fleet memberships list --format="json" --quiet --project $project | jq --raw-output '.[] | "\(.uniqueId) \(.name) \(.endpoint.kubernetesMetadata.kubernetesApiServerVersion) \(.monitoringConfig.cluster) \(.monitoringConfig.location)"')
+
+  # Apply all cluster ClusterProfiles
+  kubectl apply -f $folder
+  rm -rf $folder
+
+  # now delete obsolete memberships (run_uuid not updated)
+  while read -r name; do
+    kubectl delete clusterprofile $name -n $project
+    echo "deleted obsolete clusterprofile($name -n $project)"
+  done< <(kubectl get clusterprofile -n $project -o json -l "run_uuid,run_uuid notin ($run_uuid)" | jq --raw-output '.items[] | "\(.metadata.name)"')
+
+  echo "done with run: $run_uuid, $(date)"
+}
+
+
+while true
+do
+	echo "Press [CTRL+C] to stop.."
+  syncClusterProfiles
+	sleep 180
+done
+

--- a/fleet-clusterprofile-syncer/syncer.yaml
+++ b/fleet-clusterprofile-syncer/syncer.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: clusterprofile-syncer
+automountServiceAccountToken: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clusterprofile-syncer-deployment
+  labels:
+    app: clusterprofile-syncer
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: clusterprofile-syncer
+  template:
+    metadata:
+      labels:
+        app: clusterprofile-syncer
+      annotations:
+        date: ${DATE}
+    spec:
+      terminationGracePeriodSeconds: 0 # gotta go fast!
+      nodeSelector:
+        iam.gke.io/gke-metadata-server-enabled: "true"
+      serviceAccountName: clusterprofile-syncer
+      containers:
+      - name: syncer
+        image: ${SYNCER_DOCKER_IMAGE}
+        command: ["/usr/sbin/membership-to-clusterprofile.sh", "${PROJECT}", "${MEMBERSHIPNAME}", "${PROJECT_NUMBER}"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: clusterprofile-syncer-binding
+  labels:
+    app: clusterprofile-syncer
+subjects:
+- kind: ServiceAccount
+  name: clusterprofile-syncer
+  namespace: ${PROJECT}
+roleRef:
+  kind: ClusterRole
+  name: clusterprofileadmin
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
* Bash based for simplicity
* Supports Create, Update, Delete of ClusterProfile based on GKE Memberships.
* ClusterProfiles contain the Gateway endpoint for ease of config.