### PR TITLE
Adds support for a shorter cluster name

### DIFF
--- a/fleet-argocd-plugin/fleetclient/fleetclient.go
+++ b/fleet-argocd-plugin/fleetclient/fleetclient.go
@@ -109,6 +109,7 @@ func (c *FleetSync) startReconcile(ctx context.Context) {
 type Result struct {
 	ServerURL string `json:"server"`
 	Name      string `json:"name"`
+	NameShort strong `json:"nameShort"`
 }
 
 // PluginResults returns the results of the plugin.
@@ -142,6 +143,7 @@ func resultFromMembership(name, projectNum string) Result {
 	return Result{
 		ServerURL: connectGatewayURL(projectNum, region, membershipID),
 		Name:      fmt.Sprintf(clusterSecretNameTemplate, membershipID, region, projectNum),
+		NameShort: fmt.Sprintf(membershipID),
 	}
 }
 


### PR DESCRIPTION
Potential option to fix #11 .

Given a GKE cluster name `np-nn2-apps`, if the user passes the argument `nameShort` in the ApplicationSet, the ArgoCD Application will be prefixed with just the GKE cluster name opposed to the full Fleet name.