### PR TITLE
Update multi-cluster-orchestrator/samples/gemma_vllm/README.md

### DIFF
--- a/multi-cluster-orchestrator/samples/gemma_vllm/README.md
+++ b/multi-cluster-orchestrator/samples/gemma_vllm/README.md
@@ -308,7 +308,7 @@ metadata:
   name: gemma-vllm-placement-autoscale
   namespace: gemma-server
 spec:
-  rules:
+  clusterSelectorRules:
     - type: "all-clusters"
     - type: "cluster-name-regex"
       arguments:


### PR DESCRIPTION
update to the README to match the MultiKubernetesClusterPlacement CRD

```
❯ k explain multikubernetesclusterplacements.orchestra.multicluster.x-k8s.io.spec
GROUP:      orchestra.multicluster.x-k8s.io
KIND:       MultiKubernetesClusterPlacement
VERSION:    v1alpha1

FIELD: spec <Object>


DESCRIPTION:
    MultiKubernetesClusterPlacementSpec defines the desired state of
    MultiKubernetesClusterPlacement

FIELDS:
  clusterSelectorRules  <[]Object> -required-
    ClusterSelectorRules defines a pipeline of rules which consume an ordered
    list
    of clusters and output an ordered list of clusters to generate the list of
    current target clusters.

  scaling       <Object>
    Scaling defines the scaling configuration of the placement. If not
    specified,
    the placement will use all eligible clusters.
```