### PR TITLE
Update Dockerfile with permissions fix

### DIFF
--- a/fleet-clusterprofile-syncer/Dockerfile
+++ b/fleet-clusterprofile-syncer/Dockerfile
@@ -3,3 +3,5 @@ FROM google/cloud-sdk:latest
 RUN apt-get update && apt-get install -qqy kubectl uuid-runtime jq
 
 ADD membership-to-clusterprofile.sh /usr/sbin/membership-to-clusterprofile.sh
+
+RUN chmod +x /usr/sbin/membership-to-clusterprofile.sh


### PR DESCRIPTION
Fixes error "Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: "/usr/sbin/membership-to-clusterprofile.sh": permission denied" causing CrashLoopBackOff state in pod