### PR TITLE
doc: Fix newline escape sequence in README.md

### DIFF
--- a/gcp-auth-plugin/README.md
+++ b/gcp-auth-plugin/README.md
@@ -20,7 +20,7 @@ You can also containerize the plugin and make it available to your multi-cluster
 
 To build the container image and push to Artifacts Registry, run:
 ```shell
-gcloud artifacts repositories create gcp-auth-plugin \ 
+gcloud artifacts repositories create gcp-auth-plugin \
     --repository-format=docker \
     --location=${LOCATION} \
     --project=${PROJECT_ID}


### PR DESCRIPTION
I was testing the GCP Auth provider for Kueue and stumbled upon this in the README - there's a trailing space at the end of this line, so the newline character is not escaped and two commands are being executed:
```sh
gcloud artifacts repositories create gcp-auth-plugin (with a trailing whitespace)
```
and
```sh
    --repository-format=docker \
    --location=${LOCATION} \
    --project=${PROJECT_ID}
```