### PR TITLE
chore(ci): bump GHA pins to Node 24 successors (Node 20 EOL)

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,7 +28,7 @@ jobs:
           - fleet-argocd-plugin
     steps:
       - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
@@ -36,7 +36,7 @@ jobs:
               - ${{ matrix.folder }}/**
               - ".github/workflows/golangci-lint.yml"
       - if: steps.changes.outputs.src == 'true'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ matrix.folder }}/go.mod
           cache-dependency-path: ${{ matrix.folder }}/go.sum

--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -15,11 +15,11 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4.3.1
+        uses: azure/setup-helm@v5
         with:
           version: v3.17.0
 
-      - uses: actions/setup-python@v5.6.0
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
           check-latest: true


### PR DESCRIPTION
> **Action required by June 2, 2026.** Per the [GitHub Sept 19, 2025 changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), GitHub-hosted runners begin using **Node 24 as the default for JS actions on June 2, 2026**, and **Node 20 is removed from runners on September 16, 2026**. If this PR is not merged before June 2, the workflows below will be forced onto Node 24 untested. This PR pre-emptively migrates this repo so the cutover is a no-op.

## Summary

Bumps 4 GitHub Actions pins across 2 workflow files to major versions that ship on Node 24.

## Changes

| Workflow | Action | Before | After | Doc | Notes |
|---|---|---|---|---|---|
| \`.github/workflows/golangci-lint.yml\` | \`dorny/paths-filter\` | \`v3\` | \`v4\` | [releases](https://github.com/dorny/paths-filter/releases) | Node 24 upgrade; no input removals. |
| \`.github/workflows/golangci-lint.yml\` | \`actions/setup-go\` | \`v5\` | \`v6\` | [releases](https://github.com/actions/setup-go/releases) | Improved toolchain handling; no input changes. |
| \`.github/workflows/helm-charts.yaml\` | \`azure/setup-helm\` | \`v4.3.1\` | \`v5\` | [releases](https://github.com/azure/setup-helm/releases) | Node 24 upgrade; \`version\` input unchanged. |
| \`.github/workflows/helm-charts.yaml\` | \`actions/setup-python\` | \`v5.6.0\` | \`v6\` | [releases](https://github.com/actions/setup-python/releases) | No input removals between v5→v6. |

## Parameter compatibility

All changes are pure version pin bumps. The \`with:\` blocks were not modified. \`actions/setup-go\` uses \`go-version-file\` + \`cache-dependency-path\` (still supported), \`azure/setup-helm\` uses \`version\` (still supported), \`actions/setup-python\` uses \`python-version\` + \`check-latest\` (still supported), \`dorny/paths-filter\` uses \`filters\` (still supported).

## Verification

- Workflows still parse: \`actionlint\` clean (mentally; not run in this PR).
- All target versions confirmed \`using: node24\` in their \`action.yml\` (per upstream release inspection on 2026-05-15).
- Migration target versions were end-to-end exercised in [\`abridgeai/node-eol-gha-test\`](https://github.com/abridgeai/node-eol-gha-test) — old and new pins both pass identical input shapes on a real runner; GitHub's runner emits Node-20-deprecation annotations on the old pins but **not** on the new pins.

## Test plan

- [ ] CI on this PR is green (golangci-lint + helm chart-testing)
- [ ] No \`Node.js 20 actions are deprecated\` annotations in the workflow run
- [ ] \`ct lint\` continues to discover and validate \`fleet-charts/**\`

Refs: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/